### PR TITLE
Add support for passing post body params

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,19 @@
             },
             createOrder: async (data, actions) => {
               try {
-                const response = await fetch('/orders', {
+                const response = await fetch('/api/orders', {
                   method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  // use the "body" param to optionally pass additional order information
+                  // like product ids and quantities
+                  body: JSON.stringify({
+                    cart: [{
+                      id: 'YOUR_PRODUCT_ID',
+                      quantity: 'YOUR_PRODUCT_QUANTITY',
+                    }]
+                  }),
                 });
 
                 const details = await response.json();
@@ -41,10 +52,13 @@
             onApprove: async (data, actions) => {
               try {
                 const response = await fetch(
-                  `/orders/${data.orderID}/capture`,
+                  `/api/orders/${data.orderID}/capture`,
                   {
                     method: 'POST',
-                  }
+                    headers: {
+                      'Content-Type': 'application/json',
+                    },
+                  },
                 );
 
                 const details = await response.json();
@@ -55,7 +69,7 @@
 
                 //(3) Successful capture! For demo purposes:
                 console.log("Capture result", details, JSON.stringify(details, null, 2));
-                
+
                 const transaction = details.purchase_units[0].payments.captures[0];
                 alert(`Transaction ${transaction.status}: ${transaction.id}\n\nSee console for all available details`);
                 // When ready to go live, remove the alert and show a success message within this page. For example:


### PR DESCRIPTION
This PR contains a few changes to the API calls:
- Adds the Express body parser middleware for passing JSON data. The createOrder() callback now includes an example "cart" payload to teach devs how to pass information from the frontend to their server to create the order purchase unit details. This matches the pattern we use in the standard integration guide.
- Prefixes the create and capture order endpoints with "api" to better clarify that these routes are for apis.
- Renames the capturePayment function to captureOrder. We have a [PayPal payments api](https://developer.paypal.com/docs/api/payments/v2/) and I worry that devs could get confused between orders and payments.