### PR TITLE
Replace alert() and handle error use cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
             shape: 'rect',
             color: fundingSource === paypal.FUNDING.PAYLATER ? 'gold' : '',
           },
-          createOrder: async (data, actions) => {
+          createOrder: async (data) => {
             try {
               const response = await fetch('/api/orders', {
                 method: 'POST',
@@ -46,8 +46,21 @@
                 }),
               });
 
-              const details = await response.json();
-              return details.id;
+              const orderData = await response.json();
+              if (orderData.id) {
+                return orderData.id;
+              } else {
+                const errorDetail = orderData?.details?.[0];
+                const errorMessage = errorDetail
+                  ? `${errorDetail.issue} ${errorDetail.description} (${orderData.debug_id})`
+                  : JSON.stringify(orderData);
+
+                resultMessage(
+                  `Could not initiate PayPal Checkout...<br><br>${errorMessage}`,
+                );
+              }
+
+              return orderData.id;
             } catch (error) {
               console.error(error);
               // Handle the error or display an appropriate error message to the user
@@ -65,28 +78,37 @@
                 },
               );
 
-              const details = await response.json();
+              const orderData = await response.json();
               // Three cases to handle:
               //   (1) Recoverable INSTRUMENT_DECLINED -> call actions.restart()
               //   (2) Other non-recoverable errors -> Show a failure message
               //   (3) Successful transaction -> Show confirmation or thank you message
 
-              //(3) Successful capture! For demo purposes:
-              console.log(
-                'Capture result',
-                details,
-                JSON.stringify(details, null, 2),
-              );
+              const errorDetail = orderData?.details?.[0];
 
-              const transaction =
-                details.purchase_units[0].payments.captures[0];
-              alert(
-                `Transaction ${transaction.status}: ${transaction.id}\n\nSee console for all available details`,
-              );
-              // When ready to go live, remove the alert and show a success message within this page. For example:
-              // var element = document.getElementById('paypal-button-container');
-              // element.innerHTML = '<h3>Thank you for your payment!</h3>';
-              // Or go to another URL:  actions.redirect('thank_you.html');
+              if (errorDetail?.issue === 'INSTRUMENT_DECLINED') {
+                // (1) Recoverable INSTRUMENT_DECLINED -> call actions.restart()
+                // recoverable state, per https://developer.paypal.com/docs/checkout/standard/customize/handle-funding-failures/
+                return actions.restart();
+              } else if (errorDetail) {
+                // (2) Other non-recoverable errors -> Show a failure message
+                resultMessage(
+                  `Sorry, your transaction could not be processed. <br><br>${errorDetail.description} (${orderData.debug_id})`,
+                );
+              } else {
+                // (3) Successful transaction -> Show confirmation or thank you message
+                // Or go to another URL:  actions.redirect('thank_you.html');
+                const transaction =
+                  orderData.purchase_units[0].payments.captures[0];
+                resultMessage(
+                  `<h3>Transaction ${transaction.status}: ${transaction.id}<br><br>See console for all available details</h3>`,
+                );
+                console.log(
+                  'Capture result',
+                  orderData,
+                  JSON.stringify(orderData, null, 2),
+                );
+              }
             } catch (error) {
               console.error(error);
               // Handle the error or display an appropriate error message to the user
@@ -100,6 +122,15 @@
           console.log(`the "${fundingSource}" button is not eligible`);
         }
       });
+
+      // Example function to show a result to the user. Your site's UI library can be used instead,
+      // however alert() should not be used as it will interrupt the JS SDK window
+      function resultMessage(message) {
+        const container = document.getElementById('paypal-button-container');
+        const p = document.createElement('p');
+        p.innerHTML = message;
+        container.parentNode.appendChild(p);
+      }
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -59,8 +59,6 @@
                   `Could not initiate PayPal Checkout...<br><br>${errorMessage}`,
                 );
               }
-
-              return orderData.id;
             } catch (error) {
               console.error(error);
               // Handle the error or display an appropriate error message to the user


### PR DESCRIPTION
This PR updates three main things:
1. Replaces alert() with appending a message into the DOM. We cannot recommend using alert() since it freezes the popup and prevents it from closing (we have the same rules in our public docs)
2. There are use cases where Order Create can fail. Code has been added to handle these use cases (ex: negative amount)
3. There are use cases where a Order Capture can fail. This is still incomplete since we need to figure out how to relay the status code and payload the best we can. There are test request headers we can pass to the orders api to trigger these errors. For example, we need to ensure that we teach `actions.order.restart()` for buyer funding failures so they buyer is prompted to retry completing their payment with a different funding source in their wallet. Example screenshot of the actions.restart() flow:
<img width="1566" alt="Screen Shot 2023-08-09 at 10 59 56 AM" src="https://github.com/paypaldev/PayPal-JavaScript-FullStack-Standard-Checkout-Sample/assets/534034/d0459007-d103-49a1-89f8-9bbab192ba45">


### Error Use Cases

The following error use cases have been tested:

#### Authorization error (invalid client secret with oauth endpoint)
<img width="1138" alt="Screen Shot 2023-08-09 at 1 15 13 PM" src="https://github.com/paypaldev/PayPal-JavaScript-FullStack-Standard-Checkout-Sample/assets/534034/616f50d3-1469-4907-aee3-eefdd7fab082">

#### Invalid Order Amount (create order failure on button click)
<img width="1220" alt="Screen Shot 2023-08-09 at 1 09 47 PM" src="https://github.com/paypaldev/PayPal-JavaScript-FullStack-Standard-Checkout-Sample/assets/534034/d6e12480-a550-4c6a-9849-3220e3f1952e">


#### Invalid Order Capture
<img width="1149" alt="Screen Shot 2023-08-09 at 1 16 37 PM" src="https://github.com/paypaldev/PayPal-JavaScript-FullStack-Standard-Checkout-Sample/assets/534034/7490a641-bf2c-4b89-80fc-3fef81b82c4f">



