### PR TITLE
Improve support for negative testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,10 @@
                 throw new Error(
                   `${errorDetail.description} (${orderData.debug_id})`,
                 );
-              } else {
+              } else if (!orderData.purchase_units) {
+                throw new Error(JSON.stringify(orderData));
+              }
+              else {
                 // (3) Successful transaction -> Show confirmation or thank you message
                 // Or go to another URL:  actions.redirect('thank_you.html');
                 const transaction =

--- a/server.js
+++ b/server.js
@@ -66,6 +66,11 @@ const createOrder = async (cart) => {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
+      // Uncomment one of these to force an error for negative testing (in sandbox mode only). Documentation:
+      // https://developer.paypal.com/tools/sandbox/negative-testing/request-headers/
+      // "PayPal-Mock-Response": '{"mock_application_codes": "MISSING_REQUIRED_PARAMETER"}'
+      // "PayPal-Mock-Response": '{"mock_application_codes": "PERMISSION_DENIED"}'
+      // "PayPal-Mock-Response": '{"mock_application_codes": "INTERNAL_SERVER_ERROR"}'
     },
     method: 'POST',
     body: JSON.stringify(payload),
@@ -91,6 +96,7 @@ const captureOrder = async (orderID) => {
       // https://developer.paypal.com/tools/sandbox/negative-testing/request-headers/
       // "PayPal-Mock-Response": '{"mock_application_codes": "INSTRUMENT_DECLINED"}'
       // "PayPal-Mock-Response": '{"mock_application_codes": "TRANSACTION_REFUSED"}'
+      // "PayPal-Mock-Response": '{"mock_application_codes": "INTERNAL_SERVER_ERROR"}'
     },
   });
 
@@ -98,15 +104,16 @@ const captureOrder = async (orderID) => {
 };
 
 async function handleResponse(response) {
-  if (response.status === 500 || response.status === 503) {
+  try {
+    const jsonResponse = await response.json();
+    return {
+      jsonResponse,
+      httpStatusCode: response.status,
+    };
+  } catch (err) {
     const errorMessage = await response.text();
     throw new Error(errorMessage);
   }
-
-  return {
-    jsonResponse: await response.json(),
-    httpStatusCode: response.status,
-  };
 }
 
 app.post('/api/orders', async (req, res) => {


### PR DESCRIPTION
This PR improves support for negative testing (https://developer.paypal.com/tools/sandbox/negative-testing/request-headers/). There are few changes:
1. Update the `handleResponse()` helper function to always attempt to parse JSON regardless of status code. Even 500 errors will return JSON back so we should always try to return the JSON payload and status code back to the frontend.
2. Updates the onApprove() callback to add a check to validate the payload before considering the capture operation a success.
3. Adds a comment to the createOrder API call to show how to use the request headers for negative testing when creating an order.